### PR TITLE
gazelle/closure_js: Ignore closure_js_template_library from gazelle

### DIFF
--- a/gazelle/closure_js/resolve.go
+++ b/gazelle/closure_js/resolve.go
@@ -174,7 +174,11 @@ func resolveWithIndexJs(ix *resolve.RuleIndex, imp string, from label.Label) (la
 //
 // But, since this is unlikely to be merged, make the local (and easier) fix.
 // Require any mapped kinds to begin with "closure_js".
+//
+// Ignoring any `template` js library as gazelle is incorrectly thinking that
+// closure_js_template_library is a rule that it should pay attention to, when
+// it should be ignored
 func isJsLibrary(kind string) bool {
 	//	return kind == "closure_js_library" || kind == "closure_jsx_library"
-	return strings.HasPrefix(kind, "closure_js")
+	return strings.HasPrefix(kind, "closure_js") && !strings.Contains(kind, "_template_")
 }

--- a/gazelle/closure_js/resolve_test.go
+++ b/gazelle/closure_js/resolve_test.go
@@ -15,3 +15,23 @@ func TestResolveClosureLibrary(t *testing.T) {
 		}
 	}
 }
+func TestIsJsLibrary(t *testing.T) {
+	var tests = []struct {
+		in  string
+		out bool
+	}{
+		{"closure_js_library", true},
+		{"closure_js_test", true},
+		{"closure_jsx_library", true},
+		{"closure_jsx_test", true},
+		{"closure_js_thirdparty_library", true},
+		{"closure_js_template_library", false},
+		{"closure_jsx_template_library", false},
+	}
+	for _, test := range tests {
+		actual := isJsLibrary(test.in)
+		if actual != test.out {
+			t.Errorf("%v: expected %v, got %v", test.in, test.out, actual)
+		}
+	}
+}


### PR DESCRIPTION
Currently, gazelle is incorrectly processing `closure_js_template_library`
from processing which was causing SIGSEGV in the alpha codebase.

The fix is to ignore the template library, so that gazelle can't
process it. Also added unit tests.

**J**=SB-8301
**TEST**=manual|auto

Verified `bazel build ...` and `bazel test ...`
Verified the fix in alpha

Changing WORKSPACE to:
	local_repository(
    		name = "io_bazel_rules_closure",
    		path = "/Users/amittal/rules_closure",
	)

Run:
	$ bazel run //:gazelle_js
	Using remote cache (ny). Disable by setting BAZEL_NO_CACHE=1
	INFO: Invocation ID: eae76bd6-0b6f-4278-8db3-3e7a07c4e649
	INFO: Analyzed target //:gazelle_js (9 packages loaded, 240 targets configured).
	INFO: Found 1 target...
	Target //:gazelle_js up-to-date:
	  bazel-bin/gazelle_js-runner.bash
	  bazel-bin/gazelle_js
	INFO: Elapsed time: 8.275s, Critical Path: 1.51s
	INFO: 3 processes: 3 darwin-sandbox.
	INFO: Build completed successfully, 4 total actions
	INFO: Build completed successfully, 4 total actions
	gazelle: unused test html: js/yext/ux/ux_test.html
	gazelle: std or self import
	gazelle: std or self import
	gazelle: std or self import
	gazelle: std or self import
	gazelle: std or self import
	gazelle: std or self import
	gazelle: std or self import
	gazelle: std or self import
	gazelle: std or self import
	gazelle: std or self import
	gazelle: std or self import
	gazelle: std or self import
	gazelle: std or self import
	gazelle: std or self import
	gazelle: std or self import`
