### PR TITLE
CheckStrictDeps: resolve module paths against js module roots

### DIFF
--- a/closure/compiler/test/strict_dependency_checking/BUILD
+++ b/closure/compiler/test/strict_dependency_checking/BUILD
@@ -253,12 +253,21 @@ genrule(
 
 closure_js_library(
     name = "es6_g3_gen_lib",
-    srcs = ["es6_g.js", ":es6_g3_generate"],
+    srcs = [":es6_g_generate", ":es6_g3_generate"],
 )
 
 closure_js_binary(
     name = "es6_relative_imports_gen_srcs_bin",
+    entry_points = [
+        "closure/compiler/test/strict_dependency_checking/es6_g3.js",
+    ],
     deps = [":es6_g3_gen_lib"],
+)
+
+file_test(
+    name = "es6ModulesWithRelativeImports_compileCorrectlyWhenSourcesAreGenerated",
+    content = "console.log(\"hi\");\n",
+    file = "es6_relative_imports_gen_srcs_bin.js",
 )
 
 closure_js_library(

--- a/closure/compiler/test/strict_dependency_checking/BUILD
+++ b/closure/compiler/test/strict_dependency_checking/BUILD
@@ -245,6 +245,22 @@ genrule(
     cmd = "echo 'import { g } from \"/closure/compiler/test/strict_dependency_checking/es6_g.js\"; g();' >$@",
 )
 
+genrule(
+    name = "es6_g3_generate",
+    outs = ["es6_g3.js"],
+    cmd = "echo 'import { g } from \"./es6_g.js\"; g();' >$@",
+)
+
+closure_js_library(
+    name = "es6_g3_gen_lib",
+    srcs = ["es6_g.js", ":es6_g3_generate"],
+)
+
+closure_js_binary(
+    name = "es6_relative_imports_gen_srcs_bin",
+    deps = [":es6_g3_gen_lib"],
+)
+
 closure_js_library(
     name = "es6_g2",
     srcs = ["es6_g2.js"],

--- a/java/com/google/javascript/jscomp/CheckStrictDeps.java
+++ b/java/com/google/javascript/jscomp/CheckStrictDeps.java
@@ -149,7 +149,7 @@ abstract class CheckStrictDeps
           namespace += ".js";
         }
 
-        Webpath me = Webpath.get(t.getSourceName());
+        Webpath me = Webpath.get(convertPathToModuleName(t.getSourceName(), state.roots).or(t.getSourceName()));
         if (!me.isAbsolute()) {
           me = Webpath.get("/").resolve(me);
         }


### PR DESCRIPTION
Added  "es6_relative_imports_gen_srcs_bin" test case

Tested against existing cases and by building alpha targets:
bazel build `bazel query 'kind("closure_js_binary", //src/com/yext/consulting/customdashboards/...)'`
bazel build `bazel query 'kind("closure_js_binary", //src/com/yext/customgoals/...)'`
bazel build `bazel query 'kind("closure_js_binary", //src/com/yext/storm/...)'`
bazel build `bazel query 'kind("closure_js_binary", //js/... - (//js/yext/storm/location/categories/... + //js/demo/... + //js/yext/utils/...))'`
bazel build `bazel query 'kind("closure_js_binary", //src/com/yext/entitiesstorm/...)'`