### PR TITLE
Add option for fast dev builds with prop renaming

### DIFF
--- a/java/com/google/javascript/jscomp/JsCompiler.java
+++ b/java/com/google/javascript/jscomp/JsCompiler.java
@@ -96,6 +96,7 @@ public final class JsCompiler implements CommandLineProgram {
     boolean exportTestFunctions = false;
     boolean checksOnly = false;
     boolean disablePropertyRenaming = false;
+    boolean devBuild = false;
 
     // Compiler flags we want to read.
     Path jsOutputFile = null;
@@ -140,6 +141,9 @@ public final class JsCompiler implements CommandLineProgram {
           break;
         case "--disable_property_renaming":
           disablePropertyRenaming = true;
+          continue;
+        case "--experimental_dev_build":
+          devBuild = true;
           continue;
         default:
           break;
@@ -190,7 +194,8 @@ public final class JsCompiler implements CommandLineProgram {
             compiler,
             exportTestFunctions,
             warnings,
-            disablePropertyRenaming);
+            disablePropertyRenaming,
+            devBuild);
     if (runner.shouldRunCompiler()) {
       failed |= runner.go() != 0;
     }


### PR DESCRIPTION
This cuts down the amount of time we spend in Closure Compiler when doing a development build.

This build still does property renaming so code that works with this flag will still work when we do a production build with the advanced compilation level.

Without --experimental_dev_build
<img width="1078" alt="Screen Shot 2021-05-14 at 10 34 37 AM" src="https://user-images.githubusercontent.com/719828/118286044-11b87380-b4a0-11eb-9403-3adcd7b119d2.png">

With --experimental_dev_build
<img width="1082" alt="Screen Shot 2021-05-14 at 10 25 57 AM" src="https://user-images.githubusercontent.com/719828/118286113-1ed56280-b4a0-11eb-9779-31fffb71b703.png">
