### PR TITLE
Fix importing code from other Bazel workspaces

### DIFF
--- a/closure/compiler/closure_js_binary.bzl
+++ b/closure/compiler/closure_js_binary.bzl
@@ -147,7 +147,6 @@ def _impl(ctx):
         depset(transitive = [
             find_js_module_roots(
                 [ctx.outputs.bin],
-                ctx.workspace_name,
                 ctx.label,
                 getattr(ctx.attr, "includes", []),
             ),

--- a/closure/compiler/closure_js_library.bzl
+++ b/closure/compiler/closure_js_library.bzl
@@ -106,9 +106,6 @@ def _closure_js_library_impl(
         deprecated_stderr_file = None,
         deprecated_ijs_file = None,
         deprecated_typecheck_file = None):
-    # TODO(yannic): Figure out how to modify |find_js_module_roots|
-    # so that we won't need |workspace_name| anymore.
-
     if (
         not hasattr(ctx.files, "_ClosureWorker") or
         not hasattr(ctx.attr, "_closure_library_base") or
@@ -121,7 +118,6 @@ def _closure_js_library_impl(
     unusable_type_definition = ctx.files._unusable_type_definition
     actions = ctx.actions
     label = ctx.label
-    workspace_name = ctx.workspace_name
 
     if lenient:
         suppress = suppress + [
@@ -233,7 +229,7 @@ def _closure_js_library_impl(
     # repository, ignoring the workspace name. The exception is when the includes
     # attribute is being used, which chops the path down even further.
     js_module_roots = sort_roots(
-        find_js_module_roots(srcs, workspace_name, label, includes),
+        find_js_module_roots(srcs, label, includes),
     )
     args.add_all(js_module_roots, before_each = "--js_module_root")
 
@@ -460,4 +456,3 @@ closure_js_library = rule(
         "typecheck": "%{name}_typecheck",  # dummy output file
     },
 )
-

--- a/closure/private/defs.bzl
+++ b/closure/private/defs.bzl
@@ -69,6 +69,7 @@ def get_jsfile_path(f):
        This may be used to exclude non-JavaScript files inside tree artifacts
        expanded by Args#add_all.
     """
+
     # TODO(tjgq): Remove .zip once J2CL is switched to tree artifacts.
     return f.path if f.extension in ["js", "zip"] else None
 
@@ -167,7 +168,7 @@ def collect_runfiles(targets):
             data.append(target.default_runfiles.files)
     return depset(transitive = data)
 
-def find_js_module_roots(srcs, workspace_name, label, includes):
+def find_js_module_roots(srcs, label, includes):
     """Finds roots of JavaScript sources.
 
     This discovers --js_module_root paths for direct srcs that deviate from the
@@ -187,9 +188,10 @@ def find_js_module_roots(srcs, workspace_name, label, includes):
         srcs_it = srcs.to_list()
     roots = [f.root.path for f in srcs_it if f.root.path]
 
-    # Bazel started prefixing external repo paths with ../
-    new_bazel_version = Label("@foo//bar").workspace_root.startswith("../")
+    workspace_name = label.workspace_name
     if workspace_name != "__main__":
+        # Bazel started prefixing external repo paths with ../
+        new_bazel_version = Label("@foo//bar").workspace_root.startswith("../")
         if new_bazel_version:
             roots += ["%s" % root for root in roots.to_list()]
             roots += ["../%s" % workspace_name]
@@ -216,6 +218,7 @@ def find_js_module_roots(srcs, workspace_name, label, includes):
             for root in roots.to_list():
                 magic_roots.append("%s/%s" % (root, prefix))
         roots += magic_roots
+
     return depset(roots)
 
 def sort_roots(roots):


### PR DESCRIPTION
This change allows code from one Bazel workspace to be used from another through ES6 import statements.

Before this change, workspace_name was set incorrectly.