### PR TITLE
Embed helper functions in well-known-type protos

### DIFF
--- a/closure/protobuf/closure_proto_library.bzl
+++ b/closure/protobuf/closure_proto_library.bzl
@@ -31,11 +31,16 @@ def _generate_closure_js(target, ctx):
         "add_require_for_enums",
     ]
     # Don't add library option to well-known-types so embedded functions are added properly
-    if ctx.label.workspace_name != "com_google_protobuf":
+    if ctx.label.workspace_name == "com_google_protobuf":
+        # If library option is not specified, output file name is expected to match the input proto file name, not the bazel label name
+        # e.g. struct instead of struct_proto
+        out_file_name = ctx.label.name[:-len("_proto")]
+    else:
+        out_file_name = ctx.label.name
         js_out_options.append("library=%s" % ctx.label.name)
     if getattr(ctx.rule.attr, "testonly", False):
         js_out_options.append("testonly")
-    js = ctx.actions.declare_file("%s.js" % ctx.label.name)
+    js = ctx.actions.declare_file("%s.js" % out_file_name)
 
     # Add include paths for all proto files,
     # to avoid copying/linking the files for every target.

--- a/closure/protobuf/closure_proto_library.bzl
+++ b/closure/protobuf/closure_proto_library.bzl
@@ -28,9 +28,11 @@ def _generate_closure_js(target, ctx):
     # |goog.require()| for enums.
     js_out_options = [
         "import_style=closure",
-        "library=%s" % ctx.label.name,
         "add_require_for_enums",
     ]
+    # Don't add library option to well-known-types so embedded functions are added properly
+    if ctx.label.workspace_name != "com_google_protobuf":
+        js_out_options.append("library=%s" % ctx.label.name)
     if getattr(ctx.rule.attr, "testonly", False):
         js_out_options.append("testonly")
     js = ctx.actions.declare_file("%s.js" % ctx.label.name)


### PR DESCRIPTION
Addresses https://github.com/bazelbuild/rules_closure/issues/492

closure_proto_library is updated to omit the library option when generating JS proto files for well-known-types. This allows protoc to recognize that a well-known-type is being processed and embed the proper helper functions (e.g. Struct.fromJavaScript). When a library option is passed in, well-known-types are not recognized and treated as regular proto definitions, resulting in no helper functions being appended to the generated JS files.