### PR TITLE
Migrate transitive_runtime_deps to transitive_runtime_jars

### DIFF
--- a/closure/templates/closure_js_template_library.bzl
+++ b/closure/templates/closure_js_template_library.bzl
@@ -53,7 +53,7 @@ def _impl(ctx):
             inputs.append(f)
 
     plugin_transitive_deps = depset(
-        transitive = [m[SoyPluginInfo].generator.runtime.transitive_runtime_deps for m in ctx.attr.plugins],
+        transitive = [m[SoyPluginInfo].generator.runtime.transitive_runtime_jars for m in ctx.attr.plugins],
     ).to_list()
     inputs.extend(plugin_transitive_deps)
     plugin_classpath = [dep.path for dep in plugin_transitive_deps]


### PR DESCRIPTION
As part of the bazel 7 upgrade we need to migrate transitive_runtime_deps to now be transitive_runtime_jars
This was fixed in the upstream with this commit:
https://github.com/bazelbuild/rules_closure/commit/e8d5dfb9513fd2b05fe19f02c9dae76953a71af5