### PR TITLE
closure_proto_library: use protoc from --proto_compiler flag

### DIFF
--- a/closure/protobuf/closure_proto_library.bzl
+++ b/closure/protobuf/closure_proto_library.bzl
@@ -89,7 +89,10 @@ closure_proto_aspect = aspect(
     attrs = dict({
         # internal only
         "_protoc": attr.label(
-            default = Label("@com_google_protobuf//:protoc"),
+            # Use protoc binary from bazel flag "--proto_compiler"
+            # This allows overwriting the default @com_google_protobuf//:protoc binary
+            # and removes dependency from XCode for MacOS builds
+            default = configuration_field(fragment = "proto", name = "proto_compiler"),
             executable = True,
             cfg = "host",
         ),


### PR DESCRIPTION
This will avoid building the protoc binary in closure_proto_library targets A similar setting in rules_go
https://github.com/bazelbuild/rules_go/blob/master/proto/private/toolchain.bzl#L39