### PR TITLE
Revert "closure_proto_library: use protoc from --proto_compiler flag"

### DIFF
--- a/closure/protobuf/closure_proto_library.bzl
+++ b/closure/protobuf/closure_proto_library.bzl
@@ -84,10 +84,7 @@ closure_proto_aspect = aspect(
     attrs = dict({
         # internal only
         "_protoc": attr.label(
-            # Use protoc binary from bazel flag "--proto_compiler"
-            # This allows overwriting the default @com_google_protobuf//:protoc binary
-            # and removes dependency from XCode for MacOS builds
-            default = configuration_field(fragment = "proto", name = "proto_compiler"),
+            default = Label("@com_google_protobuf//:protoc"),
             executable = True,
             cfg = "host",
         ),


### PR DESCRIPTION
Reverts yext/rules_closure#14

https://yext.atlassian.net/browse/SB-11919
Despite the build time benefit, we are blocked from upgrading our com_google_protobuf past v21, where js support was removed. Revert this so that rules_closure use its own version of com_google_protobuf (3.19).