### PR TITLE
Use fixed version protoc 3.20.3

### DIFF
--- a/closure/private/protoc_repo.bzl
+++ b/closure/private/protoc_repo.bzl
@@ -1,0 +1,61 @@
+# Copyright 2026 The Closure Rules Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Downloads a platform-specific protoc binary."""
+
+def _get_platform(repository_ctx):
+    os_name = repository_ctx.os.name.lower()
+    arch = repository_ctx.os.arch.lower()
+
+    if os_name.startswith("mac os"):
+        if arch in ("aarch64", "x86_64"):
+            return "osx-universal_binary"
+        fail("Unsupported architecture '{}' for macOS.".format(arch))
+
+    if os_name == "linux":
+        if arch in ("amd64", "x86_64"):
+            return "linux-x86_64"
+        fail("Unsupported architecture '{}' for Linux.".format(arch))
+
+    fail("Unsupported operating system '{}'.".format(os_name))
+
+def _protoc_repo_impl(repository_ctx):
+    platform = _get_platform(repository_ctx)
+    urls = repository_ctx.attr.urls.get(platform)
+    sha256 = repository_ctx.attr.sha256s.get(platform)
+
+    if not urls:
+        fail("No protoc URLs configured for platform '{}'.".format(platform))
+    if not sha256:
+        fail("No protoc SHA256 configured for platform '{}'.".format(platform))
+
+    repository_ctx.download_and_extract(urls, sha256 = sha256)
+    repository_ctx.file("BUILD", """
+genrule(
+    name = "protoc",
+    srcs = ["bin/protoc"],
+    outs = ["protoc_bin"],
+    cmd = "cp $(location bin/protoc) $@ && chmod +x $@",
+    executable = True,
+    visibility = ["//visibility:public"],
+)
+""")
+
+protoc_repo = repository_rule(
+    implementation = _protoc_repo_impl,
+    attrs = {
+        "urls": attr.string_list_dict(mandatory = True),
+        "sha256s": attr.string_dict(mandatory = True),
+    },
+)

--- a/closure/protobuf/closure_js_proto_library.bzl
+++ b/closure/protobuf/closure_js_proto_library.bzl
@@ -35,7 +35,7 @@ def closure_js_proto_library(
         testonly = None,
         binary = 1,
         import_style = None,
-        protocbin = Label("@com_google_protobuf//:protoc"),
+        protocbin = Label("@rules_closure_protoc//:protoc"),
         **kwargs):
     cmd = ["$(location %s)" % protocbin]
     js_out_options = ["library=%s" % name]

--- a/closure/protobuf/closure_proto_library.bzl
+++ b/closure/protobuf/closure_proto_library.bzl
@@ -84,7 +84,7 @@ closure_proto_aspect = aspect(
     attrs = dict({
         # internal only
         "_protoc": attr.label(
-            default = Label("@com_google_protobuf//:protoc"),
+            default = Label("@rules_closure_protoc//:protoc"),
             executable = True,
             cfg = "host",
         ),

--- a/closure/repositories.bzl
+++ b/closure/repositories.bzl
@@ -17,6 +17,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file")
 load("@bazel_tools//tools/build_defs/repo:java.bzl", "java_import_external")
 load("//closure/private:platform_http_file.bzl", "platform_http_file")
+load("//closure/private:protoc_repo.bzl", "protoc_repo")
 
 def rules_closure_toolchains():
     """An utility method to load all Closure toolchains.
@@ -140,6 +141,7 @@ def rules_closure_dependencies(
         com_google_protobuf()
     if not omit_com_google_protobuf_js:
         com_google_protobuf_js()
+    rules_closure_protoc()
     if not omit_com_google_template_soy:
         com_google_template_soy()
     if not omit_com_google_template_soy_jssrc:
@@ -749,6 +751,23 @@ def com_google_protobuf_js():
         urls = [
             "https://github.com/protocolbuffers/protobuf/archive/v3.19.1.tar.gz",
         ],
+    )
+
+def rules_closure_protoc():
+    protoc_repo(
+        name = "rules_closure_protoc",
+        urls = {
+            "linux-x86_64": [
+                "https://github.com/protocolbuffers/protobuf/releases/download/v3.20.3/protoc-3.20.3-linux-x86_64.zip",
+            ],
+            "osx-universal_binary": [
+                "https://github.com/protocolbuffers/protobuf/releases/download/v3.20.3/protoc-3.20.3-osx-x86_64.zip",
+            ],
+        },
+        sha256s = {
+            "linux-x86_64": "44a6b498e996b845edef83864734c0e52f42197e85c9d567af55f4e3ff09d755",
+            "osx-universal_binary": "f3ac8c37e87cb345a509eef7ec614092995d9423b8effb42c207c8fbdacb97ee",
+        },
     )
 
 def com_google_template_soy():


### PR DESCRIPTION
TEST=manual

Applied the patch to alpha, verifiy protos are compiled successfully, AnalyticsStorm is built successfully:

$ bazel build //src/com/yext/analytics/analyticsstorm/... 
$ bazel query 'attr("generator_function", "yext_protos", //...)' \
   | xargs bazel build